### PR TITLE
Fix compilation errors in PomodoroController and MockInterviewService

### DIFF
--- a/interview-tracker/backend/src/main/java/com/interviewtracker/controller/PomodoroController.java
+++ b/interview-tracker/backend/src/main/java/com/interviewtracker/controller/PomodoroController.java
@@ -21,7 +21,7 @@ public class PomodoroController {
     private PomodoroService pomodoroService;
 
     @PostMapping("/start")
-    public ResponseEntity<Pomodoro> start Pomodoro(@RequestBody Map<String, Object> request) {
+    public ResponseEntity<Pomodoro> startPomodoro(@RequestBody Map<String, Object> request) {
         Long topicId = request.get("topicId") != null ? ((Number) request.get("topicId")).longValue() : null;
         String phaseStr = (String) request.get("phase");
         PomodoroPhase phase = PomodoroPhase.valueOf(phaseStr);

--- a/interview-tracker/backend/src/main/java/com/interviewtracker/service/MockInterviewService.java
+++ b/interview-tracker/backend/src/main/java/com/interviewtracker/service/MockInterviewService.java
@@ -135,7 +135,7 @@ public class MockInterviewService {
             topics.sort(Comparator.comparingInt(t ->
                 categoryCount.getOrDefault(t.getCategory(), 0)));
 
-            Topic selected Topic = topics.get(random.nextInt(Math.min(3, topics.size())));
+            Topic selectedTopic = topics.get(random.nextInt(Math.min(3, topics.size())));
             selected.add(selectedTopic);
             topics.remove(selectedTopic);
             categoryCount.merge(selectedTopic.getCategory(), 1, Integer::sum);


### PR DESCRIPTION
- Fix method name syntax error in PomodoroController.java line 24 Changed: start Pomodoro() -> startPomodoro()

- Fix variable declaration syntax error in MockInterviewService.java line 138 Changed: Topic selected Topic -> Topic selectedTopic

Both were simple camelCase syntax errors causing compilation failures.