### PR TITLE
Fix final compilation errors in ConfidenceDecayService and DataManage…

### DIFF
--- a/interview-tracker/backend/src/main/java/com/interviewtracker/service/ConfidenceDecayService.java
+++ b/interview-tracker/backend/src/main/java/com/interviewtracker/service/ConfidenceDecayService.java
@@ -109,7 +109,7 @@ public class ConfidenceDecayService {
     @Transactional
     public int applyDecayManually() {
         applyConfidenceDecay();
-        return (int) confidenceHistoryRepository.countByTopicIdAndChangeReason(null, ChangeReason.DECAY);
+        return Math.toIntExact(confidenceHistoryRepository.countByTopicIdAndChangeReason(null, ChangeReason.DECAY));
     }
 
     /**

--- a/interview-tracker/backend/src/main/java/com/interviewtracker/service/DataManagementService.java
+++ b/interview-tracker/backend/src/main/java/com/interviewtracker/service/DataManagementService.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Service;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.*;
+import java.nio.file.attribute.FileTime;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.*;


### PR DESCRIPTION
…mentService

- ConfidenceDecayService.java:112 - Use Math.toIntExact() for safe Long to int conversion
- DataManagementService.java:17 - Add missing FileTime import from java.nio.file.attribute

These were the last 2 compilation errors after fixing Lombok configuration.